### PR TITLE
docs(ssr): remove injectorsByPathname

### DIFF
--- a/docs/server-side-rendering.md
+++ b/docs/server-side-rendering.md
@@ -9,7 +9,6 @@ import { renderToString } from 'react-dom/server';
 import theme from './src/theme.treat';
 
 const injector = new VirtualStyleInjector();
-injectorsByPathname.set(pathname, injector);
 
 const html = renderToString(
   <StyleInjectorProvider injector={injector}>{element}</StyleInjectorProvider>,


### PR DESCRIPTION
Gatsby's example uses it but I'm not sure it makes sense in this example. Especially since anyway, it's not used in the snippet below showing how to inject styles.